### PR TITLE
Add configuration wizard during installation

### DIFF
--- a/build-package.sh
+++ b/build-package.sh
@@ -51,6 +51,7 @@ make_spk() {
   # copy scripts and icon
   cp -ra src/scripts ${spk_tmp_dir}
   cp -a src/PACKAGE_ICON*.PNG ${spk_tmp_dir}
+  cp -ra src/WIZARD_UIFILES ${spk_tmp_dir}
 
   # generate INFO file
   ./src/INFO.sh "${OMNIEDGE_VERSION}" ${ARCH} ${pkg_size} >"${spk_tmp_dir}"/INFO

--- a/src/WIZARD_UIFILES/install_uifile
+++ b/src/WIZARD_UIFILES/install_uifile
@@ -1,0 +1,19 @@
+[{
+    "step_title": "Omniedge Setup",
+        "items": [{
+        "type": "textfield",
+        "desc": "Please provide the network id for joining",
+        "subitems": [{
+            "key": "omniedge_network_id",
+            "desc": "Omniedge Network ID"
+        }]
+    },
+    {
+        "type": "password",
+        "desc": "Please provide the security key for login authentication",
+        "subitems": [{
+            "key": "omniedge_security_key",
+            "desc": "Omniedge Security Key"
+        }]
+    }]
+}]

--- a/src/scripts/installer
+++ b/src/scripts/installer
@@ -19,6 +19,9 @@ postinst() {
   echo "${TARGET_PATH}/bin/omniedge \$@" >>/usr/local/bin/omniedge
 
   chmod -v a+x /usr/local/bin/omniedge >>${INST_LOG} 2>&1
+
+  echo "NETWORK_ID=${omniedge_network_id}" > /var/packages/${SYNOPKG_PKGNAME}/dialog 2>&1
+  echo "SECURITY_KEY=${omniedge_security_key}" >> /var/packages/${SYNOPKG_PKGNAME}/dialog 2>&1
 }
 
 postuninst() {

--- a/src/scripts/start-stop-status
+++ b/src/scripts/start-stop-status
@@ -1,13 +1,21 @@
 #!/bin/bash
 
 SERVICE="omniedge"
-COMMAND="/usr/local/bin/omniedge join"
+COMMAND="/usr/local/bin/omniedge"
 PID_FILE="${SYNOPKG_PKGDEST}/var/omniedge.pid"
 LOG_FILE="${SYNOPKG_PKGDEST}/var/omniedge.log"
+DIALOG_FILE="/var/packages/omniedge/dialog"
+
+if [ -f "${DIALOG_FILE}" ]; then
+    . ${DIALOG_FILE}
+fi
 
 start() {
-  echo "=== Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND}" >>${LOG_FILE}
-  ${SERVICE_COMMAND} >>${LOG_FILE} 2>&1 &
+  echo "=== Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND} login" >>${LOG_FILE}
+  ${SERVICE_COMMAND} login -s ${SECURITY_KEY} -f /var/packages/omniedge/auth.json >>${LOG_FILE} 2>&1
+
+  echo "=== Starting ${SERVICE_NAME} with: ${SERVICE_COMMAND} join" >>${LOG_FILE}
+  ${SERVICE_COMMAND} join -n ${NETWORK_ID} -f /var/packages/omniedge/auth.json >>${LOG_FILE} 2>&1 &
   if [ -n "${PID_FILE}" ]; then
     echo "$!" >"${PID_FILE}"
   fi


### PR DESCRIPTION
The configuration wizard requires the network_id and security_key.